### PR TITLE
ci: split coverage into separate workflow step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
+          uv run coverage combine
           uv run coverage report --show-missing --fail-under=100
           uv run coverage xml -o coverage.xml
 


### PR DESCRIPTION
## Summary
- split test-full into a dedicated Run tests step and a separate Generate coverage report step
- keep Codecov upload behavior unchanged

## Why
This makes CI failures explicit: test failures vs coverage generation/upload issues.