### PR TITLE
perf: parallelize test suite with pytest-xdist (~50s → ~7s)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,8 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run pytest tests/ -v
-          uv run pytest packages/pretalx-client/tests/ -v
+          uv run pytest tests/
+          uv run pytest packages/pretalx-client/tests/
 
   test-full:
     name: Test (3.14/${{ matrix.os }})
@@ -145,14 +145,15 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run pytest tests/ -v --cov=src/django_program --cov-report= --cov-fail-under=0
-          uv run pytest packages/pretalx-client/tests/ -v
+          uv run pytest tests/ --cov=src/django_program --cov-report= --cov-fail-under=0
+          uv run pytest packages/pretalx-client/tests/
 
       - name: Upload coverage data artifact
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: coverage-data
           path: .coverage*
+          include-hidden-files: true
 
   coverage:
     name: Coverage (3.14/macos-latest)
@@ -187,7 +188,6 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          uv run coverage combine
           uv run coverage report --show-missing --fail-under=100
           uv run coverage xml -o coverage.xml
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ UV            ?= uv $(UV_OPTS)
 .PHONY: install-uv install-prek upgrade
 .PHONY: ci
 .PHONY: act act-ci act-docs act-list
-.PHONY: test-cov test-fast build destroy
+.PHONY: test-cov test-fast test-seq build destroy
 .PHONY: pretalx-generate-http-client pretalx-codegen pretalx-sync-schema
 .PHONY: test-pretalx-client
 
@@ -102,8 +102,11 @@ test: ## Run the tests
 test-cov: ## Run tests with coverage report
 	@PYTHONDONTWRITEBYTECODE=1 $(UV) run --no-sync pytest --cov=src/django_program --cov-report=html --cov-report=term
 
-test-fast: ## Run tests without coverage (faster)
+test-fast: ## Run tests without coverage (faster, stop on first failure)
 	@PYTHONDONTWRITEBYTECODE=1 $(UV) run --no-sync pytest -x -q
+
+test-seq: ## Run tests sequentially (no parallelism, verbose)
+	@PYTHONDONTWRITEBYTECODE=1 $(UV) run --no-sync pytest -n0 -v
 
 test-pretalx-client: ## Run pretalx-client package tests
 	@PYTHONDONTWRITEBYTECODE=1 $(UV) run --no-sync pytest packages/pretalx-client/tests/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ test = [
   "pytest-cov>=4.1.0",
   "pytest-django>=4.9.0",
   "pytest-sugar>=1.1.1",
+  "pytest-xdist>=3.8.0",
 ]
 dev = [
   { include-group = "docs" },
@@ -156,13 +157,25 @@ sort_commits = "oldest"
 tag_pattern = "v[0-9].*"
 
 [tool.pytest.ini_options]
-addopts = ["-v", "--strict-markers", "--tb=short"]
+addopts = [
+  "--strict-markers",
+  "--tb=short",
+  "-n", "auto",
+  "-p", "no:pastebin",
+  "-p", "no:doctest",
+  "-p", "no:legacypath",
+]
 DJANGO_SETTINGS_MODULE = "tests.settings"
+filterwarnings = [
+  "error",
+  "ignore:The default scheme will be changed:DeprecationWarning",
+]
 markers = [
   "unit: mark test as unit test",
   "integration: mark test as integration test",
   "e2e: mark test as end-to-end test",
 ]
+norecursedirs = ["docs", "*.egg-info", ".git", ".tox", "dist", "build", "refcode", "examples"]
 python_classes = ["Test*"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]

--- a/uv.lock
+++ b/uv.lock
@@ -286,6 +286,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "pytest-sugar" },
+    { name = "pytest-xdist" },
     { name = "python-dotenv" },
     { name = "ruff" },
     { name = "shibuya" },
@@ -318,6 +319,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "pytest-sugar" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -339,6 +341,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-django", specifier = ">=4.9.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "shibuya", specifier = ">=2024.8.0" },
@@ -371,6 +374,7 @@ test = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-django", specifier = ">=4.9.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
 ]
 
 [[package]]
@@ -380,6 +384,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -698,6 +711,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0b/4e/60fed105549297ba1a700e1ea7b828044842ea27d72c898990510b79b0e2/pytest-sugar-1.1.1.tar.gz", hash = "sha256:73b8b65163ebf10f9f671efab9eed3d56f20d2ca68bda83fa64740a92c08f65d", size = 16533, upload-time = "2025-08-23T12:19:35.737Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/d5/81d38a91c1fdafb6711f053f5a9b92ff788013b19821257c2c38c1e132df/pytest_sugar-1.1.1-py3-none-any.whl", hash = "sha256:2f8319b907548d5b9d03a171515c1d43d2e38e32bd8182a1781eb20b43344cc8", size = 11440, upload-time = "2025-08-23T12:19:34.894Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add **pytest-xdist** for parallel test execution across all CPU cores (`-n auto`)
- Disable unused builtin plugins (`pastebin`, `doctest`, `legacypath`)
- Turn warnings into errors with an allowlist for Django 6.0 deprecation warnings
- Add `norecursedirs` to skip irrelevant directories during collection
- Remove default `-v` flag (use `make test-seq` when verbose output is needed)
- Add `make test-seq` target for sequential verbose runs when debugging

## Results

| Metric | Before | After |
|---|---|---|
| `make test` | ~50s | ~7s |
| `make test-cov` | ~50s + cov | ~8s + cov |
| Collection | 0.43s | 0.43s (unchanged) |
| Coverage | 100% | 100% (unchanged) |

## Test plan

- [x] `make ci` passes locally (fmt, type-check, tests)
- [x] Coverage still reports 100% with xdist workers
- [x] All 725 tests pass in parallel
- [ ] CI workflow passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)