### PR TITLE
fix: correct git-cliff-action SHA to v4.7.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
       - name: Generate changelog
-        uses: orhun/git-cliff-action@14bb12647b0c60374018bc3b4e01349e6e0a5340 # v4.4.2
+        uses: orhun/git-cliff-action@e16f179f0be49ecdfe63753837f20b9531642772 # v4.7.0
         with:
           config: pyproject.toml
           args: --output docs/changelog.md


### PR DESCRIPTION
## Summary
- The `orhun/git-cliff-action` SHA `14bb12647b0c60374018bc3b4e01349e6e0a5340` (tagged as v4.4.2) no longer resolves — GitHub returns 404 when fetching the tarball
- Updated to `e16f179f0be49ecdfe63753837f20b9531642772` which is the current `v4.7.0` release

## Test plan
- [ ] CD workflow runs successfully on merge (changelog job completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)