### PR TITLE
fix: correct create-pull-request SHA typo in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,7 +40,7 @@ jobs:
           args: --output docs/changelog.md
 
       - name: Create changelog PR
-        uses: peter-evans/create-pull-request@c0f553fe549906ede0cf27b5156039d195d2ece0 # v8.1.0
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "docs: update changelog"


### PR DESCRIPTION
## Summary
- `peter-evans/create-pull-request` SHA had a single-character typo: `ede0cf27` should be `ede9cf27`
- This was the remaining failure after #33 fixed the `git-cliff-action` SHA

## Test plan
- [ ] CD workflow Changelog job completes successfully on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)